### PR TITLE
Adjust global description metadata

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ title                    : "MAVERIC"
 title_separator          : "-"
 subtitle                 : Researching 5G Campus Networks
 name                     : ""
-description              : "An amazing website."
+description              : "Middleware for Automated use of Edge Resources In Campus networks"
 url                      : "https://maveric-project.org"
 baseurl                  : # the subpath of your site, e.g. "/blog"
 repository               : # GitHub username/repo-name e.g. "mmistakes/minimal-mistakes"


### PR DESCRIPTION
While sending a link to the "Publications" page in a messenger, I noticed that the `og:description` meta tag currently has a default value of "An amazing website", leading to link previews like the following:

<img width="208" alt="image" src="https://github.com/MAVERIC-Project/MAVERIC-Project.github.io/assets/12641361/d05f2ef7-7ce9-4eb0-bffc-0a5d83f56c57">

While the website definitely is amazing, this PR adjusts the default value in the top-level `_config.yml` file so that it displays the written-out MAVERIC acronym instead (which is probably even more fitting).